### PR TITLE
Added the ability to set a default scene

### DIFF
--- a/OBS.cs
+++ b/OBS.cs
@@ -1,5 +1,7 @@
 ﻿using OBS.WebSocket.NET;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace PowerPointToOBSSceneSwitcher
@@ -9,6 +11,8 @@ namespace PowerPointToOBSSceneSwitcher
 	{
 		private bool _DisposedValue;
 		private ObsWebSocket _OBS;
+		private List<string> validScenes;
+		private string defaultScene;
 
 		public ObsLocal() { }
 
@@ -18,11 +22,52 @@ namespace PowerPointToOBSSceneSwitcher
 			_OBS.Connect($"ws://127.0.0.1:4444", "");
 			return Task.CompletedTask;
 		}
-	
+
+		public string DefaultScene
+        {
+            get { return defaultScene; }
+			set
+			{
+				if (validScenes.Contains(value))
+				{
+					defaultScene = value;
+				}
+                else
+                {
+                    Console.WriteLine($"Scene named {value} does not exist and cannot be set as default");
+                }
+			}
+        }
+
 		public bool ChangeScene(string scene)
         {
+			if (!validScenes.Contains(scene))
+			{
+                Console.WriteLine($"Scene named {scene} does not exist");
+				if (String.IsNullOrEmpty(defaultScene))
+				{
+                    Console.WriteLine("No default scene has been set!");
+					return false;
+				}
+			
+				scene = defaultScene;
+			}
+
 			_OBS.Api.SetCurrentScene(scene);
+
 			return true;
+        }
+
+		public void GetScenes()
+        {
+			var allScene = _OBS.Api.GetSceneList();
+			var list = allScene.Scenes.Select(s => s.Name).ToList();
+            Console.WriteLine("Valid Scenes:");
+			foreach(var l in list)
+            {
+                Console.WriteLine(l);
+            }
+			validScenes = list;
         }
 
 		protected virtual void Dispose(bool disposing)

--- a/Program.cs
+++ b/Program.cs
@@ -45,21 +45,28 @@ namespace PowerPointToOBSSceneSwitcher
                 {
                     if (line.StartsWith("OBS:")) {
                         line = line.Substring(4).Trim();
-                        Console.WriteLine($"  Switching to OBS Scene named \"{line}\"");
 
-                        try 
-                        { 
-                            sceneHandled = OBS.ChangeScene(line); 
-                        }
-                        catch(Exception ex)
+                        if (!sceneHandled)
                         {
-                             Console.WriteLine($"  ERROR: {ex.Message.ToString()}"); 
+                            Console.WriteLine($"  Switching to OBS Scene named \"{line}\"");
+                            try
+                            {
+                                sceneHandled = OBS.ChangeScene(line);
+                            }
+                            catch (Exception ex)
+                            {
+                                Console.WriteLine($"  ERROR: {ex.Message.ToString()}");
+                            }
+                        }
+                        else
+                        { 
+                            Console.WriteLine($"  WARNING: Multiple scene definitions found.  I used the first and have ignored \"{line}\"");
                         }
                     }
 
                     if(line.StartsWith("OBSDEF:"))
                     {
-                        OBS.DefaultScene = line.Substring(7);
+                        OBS.DefaultScene = line.Substring(7).Trim();
                         Console.WriteLine($"  Setting the default OBS Scene to \"{OBS.DefaultScene}\"");
                     }
 

--- a/Program.cs
+++ b/Program.cs
@@ -24,6 +24,8 @@ namespace PowerPointToOBSSceneSwitcher
             Console.ReadLine();
         }
 
+        static string DefaultScene = string.Empty;
+
         async static void App_SlideShowNextSlide(SlideShowWindow Wn)
         {
             if (Wn != null)
@@ -33,10 +35,33 @@ namespace PowerPointToOBSSceneSwitcher
                 var note = String.Empty;
                 try { note = Wn.View.Slide.NotesPage.Shapes[2].TextFrame.TextRange.Text; }
                 catch { /*no notes*/ }
-                if (note.StartsWith("OBS:")) {
-                    note = new StringReader(note).ReadLine().Substring(4);
-                    Console.WriteLine($"  Switching to OBS Scene named \"{note}\"");
-                    OBS.ChangeScene(note);
+
+                bool sceneHandled = false;
+
+                var splitnotes = note.Split('\r');
+
+                foreach (var line in splitnotes)
+                {
+                    if (line.StartsWith("OBS:"))
+                    {
+                        var sceneLine = line.Substring(4);
+                        Console.WriteLine($"  Switching to OBS Scene named \"{sceneLine}\"");
+                        OBS.ChangeScene(sceneLine);
+                        sceneHandled = true;
+                    }
+
+                    if(line.StartsWith("OBSDEF:"))
+                    {
+                        DefaultScene = line.Substring(7);
+                        Console.WriteLine($"  Setting the default OBS Scene to \"{DefaultScene}\"");
+                    }
+
+                    if (!sceneHandled)
+                    {
+                        OBS.ChangeScene(DefaultScene);
+                        Console.WriteLine($"  Switching to OBS Default Scene named \"{DefaultScene}\"");
+
+                    }
                 }
             }
         }

--- a/Program.cs
+++ b/Program.cs
@@ -21,10 +21,10 @@ namespace PowerPointToOBSSceneSwitcher
             await OBS.Connect();
             Console.WriteLine("connected");
 
+            OBS.GetScenes();
+
             Console.ReadLine();
         }
-
-        static string DefaultScene = string.Empty;
 
         async static void App_SlideShowNextSlide(SlideShowWindow Wn)
         {
@@ -46,20 +46,19 @@ namespace PowerPointToOBSSceneSwitcher
                     {
                         var sceneLine = line.Substring(4);
                         Console.WriteLine($"  Switching to OBS Scene named \"{sceneLine}\"");
-                        OBS.ChangeScene(sceneLine);
-                        sceneHandled = true;
+                        sceneHandled = OBS.ChangeScene(sceneLine);
                     }
 
                     if(line.StartsWith("OBSDEF:"))
                     {
-                        DefaultScene = line.Substring(7);
-                        Console.WriteLine($"  Setting the default OBS Scene to \"{DefaultScene}\"");
+                        OBS.DefaultScene = line.Substring(7);
+                        Console.WriteLine($"  Setting the default OBS Scene to \"{OBS.DefaultScene}\"");
                     }
 
                     if (!sceneHandled)
                     {
-                        OBS.ChangeScene(DefaultScene);
-                        Console.WriteLine($"  Switching to OBS Default Scene named \"{DefaultScene}\"");
+                        OBS.ChangeScene(OBS.DefaultScene);
+                        Console.WriteLine($"  Switching to OBS Default Scene named \"{OBS.DefaultScene}\"");
 
                     }
                 }

--- a/Program.cs
+++ b/Program.cs
@@ -49,9 +49,9 @@ namespace PowerPointToOBSSceneSwitcher
 
                         try 
                         { 
-                            sceneHandled = OBS.ChangeScene(sceneLine); 
+                            sceneHandled = OBS.ChangeScene(line); 
                         }
-                        catch 
+                        catch(Exception ex)
                         {
                              Console.WriteLine($"  ERROR: {ex.Message.ToString()}"); 
                         }

--- a/README.md
+++ b/README.md
@@ -6,3 +6,14 @@ Note this won't build with "dotnet build," instead open a Visual Studio 2019 Dev
 This video explains how it works!
 
 [![Watch the video](https://i.imgur.com/v369AtP.png)](https://www.youtube.com/watch?v=ciNcxi2bPwM)
+
+## Usage
+* Set a scene for a slide with 
+```<language>
+    OBS:{Scene name as it appears in OBS}
+```
+
+* Set a default scene (used when a scene is not defined) with
+```<language>
+    OBSDEF:{Scene name as it appears in OBS}
+```


### PR DESCRIPTION
Totally non-production ready code, but this adds the ability to define a default scene the notes of in any page with the syntax 'OBSDEF:MySceneName'
If set multiple times it can allow the default to be changed mid-presentation.