### PR TITLE
Allow the OBS directive to appear on any line in the notes

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -33,10 +33,18 @@ namespace PowerPointToOBSSceneSwitcher
                 var note = String.Empty;
                 try { note = Wn.View.Slide.NotesPage.Shapes[2].TextFrame.TextRange.Text; }
                 catch { /*no notes*/ }
-                if (note.StartsWith("OBS:")) {
-                    note = new StringReader(note).ReadLine().Substring(4);
-                    Console.WriteLine($"  Switching to OBS Scene named \"{note}\"");
-                    OBS.ChangeScene(note);
+
+                var notereader = new StringReader(note);
+                string line;
+                while ((line = notereader.ReadLine()) != null)
+                {
+                    if (line.StartsWith("OBS:")) {
+                        line = line.Substring(4).Trim();
+                        Console.WriteLine($"  Switching to OBS Scene named \"{line}\"");
+                        try { OBS.ChangeScene(line); }
+                        catch { Console.WriteLine($"  FAILED! Is there such a scene?"); }
+                        break;
+                    }
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # PowerPointToOBSSceneSwitcher
-A .NET core based scene switcher than connects to OBS and changes scenes based note meta data. Put "OBS:Your Scene Name" as the first line in your notes and ensure the OBS Web Sockets Server is running and this app will change your scene as you change your PowerPoint slides.
+A .NET core based scene switcher than connects to OBS and changes scenes based note meta data. Put "OBS:Your Scene Name" on its own line in your notes and ensure the OBS Web Sockets Server is running and this app will change your scene as you change your PowerPoint slides.
 
 Note this won't build with "dotnet build," instead open a Visual Studio 2019 Developer Command Prompt and build with "msbuild"
 


### PR DESCRIPTION
Scott, I thought his change might be helpful, as I sometimes like to use the notes for some prompts for when I'm presenting. In addition, this includes a fix for #2 